### PR TITLE
Fix/ci yaml suffix

### DIFF
--- a/.azure-devops-ci.yaml
+++ b/.azure-devops-ci.yaml
@@ -43,11 +43,18 @@ steps:
   condition: succeededOrFailed()
 
 - task: YodLabs.VariableTasks.SetVariable.SetVariable@0
-  displayName: 'Set Variable NUGET_PACKAGE_VERSION_SUFFIX to -alpha with  applied'
+  displayName: 'Set Variable NUGET_PACKAGE_VERSION_SUFFIX to -alpha for non-master builds'
   inputs:
     variableName: 'NUGET_PACKAGE_VERSION_SUFFIX'
     value: '-alpha'
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+- task: YodLabs.VariableTasks.SetVariable.SetVariable@0
+  displayName: 'Set Variable NUGET_PACKAGE_VERSION_SUFFIX to <blank> for master builds'
+  inputs:
+    variableName: 'NUGET_PACKAGE_VERSION_SUFFIX'
+    value: ''
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
 - task: YodLabs.VariableTasks.SetVariable.SetVariable@0
   displayName: 'Set Variable NUGET_PACKAGE_VERSION to 1.0.$(Build.BuildNumber)$(NUGET_PACKAGE_VERSION_SUFFIX) with  applied'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Fake Db Provider for System.Data.Common.DbConnection
 
+## Master Branch Status
+
+* [![Build Status](https://johnhgoodwin.visualstudio.com/Public/_apis/build/status/FakeDbProvider-CI?branchName=master)](https://johnhgoodwin.visualstudio.com/Public/_build/latest?definitionId=3&branchName=master)
+
 Sometimes mocking just isn't enough, so you need a realistic double. This is where fakes come in.
 
 To get started, I copied the code from here:


### PR DESCRIPTION
Fixed CI definition did not set the nuget version suffix for master branch to blank.